### PR TITLE
Update download_TCGA.sh

### DIFF
--- a/download_data/download_TCGA.sh
+++ b/download_data/download_TCGA.sh
@@ -8,7 +8,7 @@ mkdir $raw_folder
 ./gdc-client/bin/gdc-client 'download' -m $manifest_folder'manifest.txt' -d $raw_folder
 
 # Supplement can be changed and retrieved from here https://academic.oup.com/bioinformatics/article/32/19/2891/2196464#supplementary-data
-wget -O $raw_folder'response.zip' "https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/bioinformatics/32/19/10.1093_bioinformatics_btw344/4/btw344_supplementary_data.zip?Expires=1597162292&Signature=C7PIMtzXJtaP3W5ke2Et0LfPq4IEweLqXeJlylOXY0E24BuHzDc2hGyIVx5L2JqnDnPz2LFuLzTNiWRRuRbh0OgZVGFH5SG3jM52vmVtQFNi59xKuZs1IqnsbGFRUz7L7ggoPxpK2uNKDCbmSRSzPOgIcGdTWZQyYHgCknx0E4X~FkEm4ucOWfL5dxbKIcloDsPn85eW8sul3r43x0g9Zt~ioJFG9ysoMen9jyxhFZiwlsq5GkupvKLKLcW1Mk6qZ2jXfBmCBZfP0m9ejYR6565na0AXpNK-iYx4xioLpfMWmK0Kda~lD7HLc0vZbVvCPgn9biok2L9CPisf8XHOhQ__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA"
+wget -O $raw_folder'response.zip' "https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/bioinformatics/32/19/10.1093_bioinformatics_btw344/4/btw344_supplementary_data.zip?Expires=1607528148&Signature=rqaiCbQpJSF2YCxht9jv6TdaFHrajCifzKO-CrHsC~qlTBwkvweF-usl1-v8~ihJPoCk0OgQD7aNpwPJiNnxka6LTBs4-C87DbEOlo2RARZwLg52rsB-aAXolty8S92QSY7DC3k3HrksQYpCI-b1xWfIfHWtSK6SEwIWnjvC6Hcpz9U0y6kyvk1P0Tvgkpt4q4eWGM3W0yFw68LnNjxh7xLNf9JRRfRKj2wPokR4mMt8BNoy15C7UVvblQY0gZkNy23Rlwi2pd0s2tQBF7~PD4yo3JpHrokd29Q~yf9dzwOvsxDxEz9NrGn8IfA~eshtvzvySlWFvOE21YZclkHpDg__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA"
 unzip $raw_folder'response.zip' -d $raw_folder
 
 python ./TCGA_dependencies/download_TCGA.py


### PR DESCRIPTION
wget url to supplementary data was not up to date. Replaced it by the current (4th of November 2020) url.